### PR TITLE
Load all sets in exercise graph view

### DIFF
--- a/app/Http/Controllers/ExerciseController.php
+++ b/app/Http/Controllers/ExerciseController.php
@@ -164,7 +164,7 @@ class ExerciseController extends Controller
     public function getSets($id)
     {
         $exercise = Exercise::find($id);
-        $allSets = Auth::user()->workout_sets()->orderBy('created_at')->where('exercise_id', $exercise->id)->get();
+        $allSets = Auth::user()->workout_sets()->orderBy('created_at', 'desc')->where('exercise_id', $exercise->id)->get();
         return(response()->json($allSets));
     }
 

--- a/resources/assets/js/components/exercise/Card.js
+++ b/resources/assets/js/components/exercise/Card.js
@@ -17,26 +17,28 @@ export function Card({ exercise }) {
 
 	const updateSets = async () => {
 		setIsLoading(true);
-		await axios.get(`/ajax/exercise/${exercise.id}/sets`).then(response => {
-			setSets(
-				response.data.map((set, i) => {
-					if (set.date === moment(new Date()).format("MMM DD[,] YYYY")) {
-						setShowEdit(true);
-					}
-					return (
-						<ExerciseCardRow
-							key={i}
-							id={set.id}
-							exercise_id={exerciseId}
-							date={set.date}
-							weight={set.weight}
-							reps={set.reps}
-						/>
-					);
-				})
-			);
-			setIsLoading(false);
-		});
+		await axios
+			.get(`/ajax/dashboard/exercise/${exercise.id}/sets`)
+			.then(response => {
+				setSets(
+					response.data.map((set, i) => {
+						if (set.date === moment(new Date()).format("MMM DD[,] YYYY")) {
+							setShowEdit(true);
+						}
+						return (
+							<ExerciseCardRow
+								key={i}
+								id={set.id}
+								exercise_id={exerciseId}
+								date={set.date}
+								weight={set.weight}
+								reps={set.reps}
+							/>
+						);
+					})
+				);
+				setIsLoading(false);
+			});
 	};
 
 	return (

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,6 @@ Route::get('/faker/set', 'TestController@FakeSets');
 Route::get('/ajax/exercise', 'HomeController@indexData');
 Route::get('/ajax/exercise/add', 'ExerciseController@addAjax');
 Route::get('/ajax/exercise/{id}/btns', 'ExerciseController@GetButtons');
-Route::get('/ajax/exercise/{id}/sets', 'ExerciseController@getSetsForDashboard');
+Route::get('/ajax/dashboard/exercise/{id}/sets', 'ExerciseController@getSetsForDashboard');
 Route::post('/ajax/set/store', 'WorkoutSetController@saveAjax');
 Route::post('/ajax/set/{id}/update', 'WorkoutSetController@updateAjax');


### PR DESCRIPTION
Fixes #89.

Fixes route naming where two routes shared a path.

Corrects set ordering by date