### PR TITLE
Add PropTypes to components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,10 @@
         "browser": true,
         "es6": true
     },
-    "extends": "eslint:recommended",
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended"
+        ],
     "globals": {
         "Atomics": "readonly",
         "SharedArrayBuffer": "readonly"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "eslint-config-airbnb": "^17.1.1",
         "eslint-plugin-import": "^2.18.2",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-react": "^7.14.2",
+        "eslint-plugin-react": "^7.14.3",
         "jquery": "^3.2",
         "laravel-mix": "^2.0",
         "lodash": "^4.17.4",
@@ -35,6 +35,7 @@
     "dependencies": {
         "chart.js": "^2.8.0",
         "moment": "^2.23.0",
+        "prop-types": "^15.7.2",
         "react-bootstrap": "^1.0.0-beta.3",
         "react-chartkick": "^0.3.0",
         "react-collapse": "^4.0.3",

--- a/resources/assets/js/components/NavItem.js
+++ b/resources/assets/js/components/NavItem.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 
 export function NavItem({ name, link }) {
@@ -10,3 +11,8 @@ export function NavItem({ name, link }) {
 		</Link>
 	);
 }
+
+NavItem.propTypes = {
+	name: PropTypes.string.isRequired,
+	link: PropTypes.string.isRequired
+};

--- a/resources/assets/js/components/auth/Login.js
+++ b/resources/assets/js/components/auth/Login.js
@@ -3,6 +3,7 @@ import { Row, Col, Card, Form, InputGroup, Button } from "react-bootstrap";
 import axios from "axios";
 import ReactLoading from "react-loading";
 import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
 
 export function Login({ setMessage }) {
 	const [email, setEmail] = useState("");
@@ -112,3 +113,7 @@ export function Login({ setMessage }) {
 		</Card>
 	);
 }
+
+Login.propTypes = {
+	setMessage: PropTypes.func.isRequired
+};

--- a/resources/assets/js/components/auth/Register.js
+++ b/resources/assets/js/components/auth/Register.js
@@ -3,6 +3,8 @@ import { Row, Col, Card, Form, InputGroup, Button } from "react-bootstrap";
 import axios from "axios";
 import ReactLoading from "react-loading";
 import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+import { Login } from "./Login";
 
 export function Register({ setMessage }) {
 	const [name, setName] = useState("");
@@ -158,3 +160,7 @@ export function Register({ setMessage }) {
 		</Card>
 	);
 }
+
+Register.propTypes = {
+	setMessage: PropTypes.func.isRequired
+};

--- a/resources/assets/js/components/dashboard/TopPanel.js
+++ b/resources/assets/js/components/dashboard/TopPanel.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 import { Col, Row } from "react-bootstrap";
+import PropTypes from "prop-types";
 
-export function TopPanel({ pageName, user }) {
+export function TopPanel({ pageName, userName }) {
 	return (
 		<div className="dashboard-top-panel">
 			<Row>
@@ -14,10 +15,15 @@ export function TopPanel({ pageName, user }) {
 				<Col md={12} lg={4}>
 					<div className="auth">
 						<span className="icon">icon</span>
-						{user}
+						{userName}
 					</div>
 				</Col>
 			</Row>
 		</div>
 	);
 }
+
+TopPanel.propTypes = {
+	pageName: PropTypes.string.isRequired,
+	userName: PropTypes.string.isRequired
+};

--- a/resources/assets/js/components/exercise/Card.js
+++ b/resources/assets/js/components/exercise/Card.js
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom";
 import { CardRow as ExerciseCardRow } from "./CardRow";
 import { QuickAdder } from "./QuickAdder";
 import moment from "moment";
+import PropTypes from "prop-types";
 
 export function Card({ exercise }) {
 	const [sets, setSets] = useState([]);
@@ -117,3 +118,10 @@ export function Card({ exercise }) {
 		</div>
 	);
 }
+
+Card.propTypes = {
+	exercise: PropTypes.shape({
+		name: PropTypes.string.isRequired,
+		id: PropTypes.number.isRequired
+	}).isRequired
+};

--- a/resources/assets/js/components/exercise/CardRow.js
+++ b/resources/assets/js/components/exercise/CardRow.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import moment from "moment";
 import { InputGroup, FormControl, Button } from "react-bootstrap";
 import axios from "axios";
+import PropTypes from "prop-types";
 
 export function CardRow({ id, exercise_id, date, weight, reps }) {
 	const [setId, setSetId] = useState(id);
@@ -99,3 +100,11 @@ export function CardRow({ id, exercise_id, date, weight, reps }) {
 		</tr>
 	);
 }
+
+CardRow.propTypes = {
+	id: PropTypes.number.isRequired,
+	exercise_id: PropTypes.number.isRequired,
+	date: PropTypes.string.isRequired,
+	weight: PropTypes.number.isRequired,
+	reps: PropTypes.number.isRequired
+};

--- a/resources/assets/js/components/exercise/Graph.js
+++ b/resources/assets/js/components/exercise/Graph.js
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import axios from "axios";
 import ReactChartkick, { LineChart } from "react-chartkick";
 import Chart from "chart.js";
+import PropTypes from "prop-types";
 
 export function Graph({ match }) {
 	const [exerciseId, setExerciseId] = useState(match.params.exerciseId);
@@ -74,3 +75,11 @@ export function Graph({ match }) {
 		</div>
 	);
 }
+
+Graph.propTypes = {
+	match: PropTypes.shape({
+		params: PropTypes.shape({
+			exerciseId: PropTypes.string.isRequired
+		}).isRequired
+	}).isRequired
+};

--- a/resources/assets/js/components/exercise/QuickAdder.js
+++ b/resources/assets/js/components/exercise/QuickAdder.js
@@ -11,6 +11,7 @@ import {
 	Spinner
 } from "react-bootstrap";
 import { DEFAULT_SET_REPS, DEFAULT_SET_WEIGHT, KG_PER_LB } from "../../const";
+import PropTypes from "prop-types";
 
 export function QuickAdder({ exercise_id, updater, toggle }) {
 	const [exerciseId, setExerciseId] = useState(exercise_id);
@@ -187,3 +188,9 @@ export function QuickAdder({ exercise_id, updater, toggle }) {
 		</div>
 	);
 }
+
+QuickAdder.propTypes = {
+	exercise_id: PropTypes.number.isRequired,
+	updater: PropTypes.func.isRequired,
+	toggle: PropTypes.func.isRequired
+};

--- a/resources/assets/js/layouts/DashboardLayout.js
+++ b/resources/assets/js/layouts/DashboardLayout.js
@@ -10,7 +10,7 @@ export function DashboardLayout() {
 	return (
 		<BrowserRouter>
 			<div className="layout">
-				<TopPanel pageName="Exercises" user="bar" />
+				<TopPanel pageName="Exercises" userName="bar" />
 				<SidePanel />
 				{/* Routes */}
 				<Route exact path="/" component={Dashboard} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2670,10 +2670,10 @@ eslint-plugin-jsx-a11y@^6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
-eslint-plugin-react@^7.14.2:
-  version "7.14.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.2.tgz#94c193cc77a899ac0ecbb2766fbef88685b7ecc1"
-  integrity sha512-jZdnKe3ip7FQOdjxks9XPN0pjUKZYq48OggNMd16Sk+8VXx6JOvXmlElxROCgp7tiUsTsze3jd78s/9AFJP2mA==
+eslint-plugin-react@^7.14.3:
+  version "7.14.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz#911030dd7e98ba49e1b2208599571846a66bdf13"
+  integrity sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==
   dependencies:
     array-includes "^3.0.3"
     doctrine "^2.1.0"


### PR DESCRIPTION
This PR adds the `eslint-plugin-react` and `prop-types`  dependencies to the repo.
`eslint-plugin-react` adds ESLint rules for React. One of these rules is enforcing PropTypes on all components. This is great as it enforces typing on components, helping to debug and write stable code